### PR TITLE
27 address UI bugs and tweaks

### DIFF
--- a/src/Components/Album.tsx
+++ b/src/Components/Album.tsx
@@ -64,7 +64,6 @@ export default function Album() {
                 <main
                     style={{
                         backgroundColor: '#9c6644',
-                        paddingBottom: '10%',
                     }}
                 >
                     <Box

--- a/src/Components/Showcase.tsx
+++ b/src/Components/Showcase.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import Typography from '@mui/material/Typography';
-import { Button, Link } from '@mui/material';
 
 // Props for Showcase component
 export interface ShowcaseProps {
@@ -45,19 +44,8 @@ const Showcase: React.FC<ShowcaseProps> = ({
                 <div data-testid="descrip">
                     Description: {description} <br />
                 </div>
-                <a
-                    onClick={() => {
-                        const iframe =
-                            "<iframe width='100%' style='border:none;' height='100%' src='" +
-                            image +
-                            "'==></iframe>";
-                        const x = window.open();
-                        x?.document.open();
-                        x?.document.write(iframe);
-                        x?.document.close();
-                    }}
-                >
-                    Full Resolution
+                <a download={title} href={image}>
+                    Download image
                 </a>
             </Typography>
         </div>

--- a/src/Components/Showcase.tsx
+++ b/src/Components/Showcase.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import Typography from '@mui/material/Typography';
-import { Link } from '@mui/material';
+import { Button, Link } from '@mui/material';
 
 // Props for Showcase component
 export interface ShowcaseProps {
@@ -45,9 +45,20 @@ const Showcase: React.FC<ShowcaseProps> = ({
                 <div data-testid="descrip">
                     Description: {description} <br />
                 </div>
-                <Link href={image} underline="none">
-                    {'Full resolution'}
-                </Link>
+                <a
+                    onClick={() => {
+                        const iframe =
+                            "<iframe width='100%' style='border:none;' height='100%' src='" +
+                            image +
+                            "'==></iframe>";
+                        const x = window.open();
+                        x?.document.open();
+                        x?.document.write(iframe);
+                        x?.document.close();
+                    }}
+                >
+                    Full Resolution
+                </a>
             </Typography>
         </div>
     );

--- a/src/index.css
+++ b/src/index.css
@@ -31,6 +31,11 @@ a:hover {
     text-shadow: 2px 2px #000000;   
 }
 
+main{
+    min-height: 100vh;
+    padding-bottom: 10%;
+}
+
 .container {
     min-height: 100vh;
     width: 100%;
@@ -48,4 +53,5 @@ a:hover {
     right: 0px;
     bottom: 0px;
     left: 0px;
+    min-height: 100vh;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -12,18 +12,26 @@ body {
     padding: 0;
 }
 
-.MuiBadge-root:hover{
+a {
+    color:rgb(30, 49, 255);
+}
+
+a:hover {
     cursor: pointer;
 }
 
-#load{
+.MuiBadge-root:hover {
+    cursor: pointer;
+}
+
+#load {
     padding-top: 20%;
     color: #ffffff;
     text-align: center;
     text-shadow: 2px 2px #000000;   
 }
 
-.container{
+.container {
     min-height: 100vh;
     width: 100%;
     background-color: #827081;


### PR DESCRIPTION
Closes #27 

Fixed the issue with images not displaying in a new tab on Chrome browsers by tweaking the functionality. Now users are able to download the Base64 image directly as a file to their computer, and this seems to work irregardless of browser. 

Also added `min-height: 100vh` styling to the main app which should prevent white boxing at the bottom of the page when there is a lack of photo entries.